### PR TITLE
feat: update error propagation to not use MCMC posteriors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 Code to estimate asymtptotic core-collapse supernova explosion energy following the methods of  [Murphy et al. 2019](https://ui.adsabs.harvard.edu/abs/2019MNRAS.489..641M/abstract).
-Fit a physically motivated functional form for the time dependence of the explosion energy using [emcee](https://emcee.readthedocs.io/en/stable/index.html).
+Fit a physically motivated functional form for the time dependence of the explosion energy using MCMC methods using [emcee](https://emcee.readthedocs.io/en/stable/index.html).
 
 ## Functional Form
 We fit a function of the following form


### PR DESCRIPTION
Updates `propagate_errors` to use the MCMC posteriors from `self.flat_samples` instead of assuming normally distributed uncertainties on log(E). 